### PR TITLE
feat(release): add docker_file input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         default: '.'
         required: false
         type: string
+      docker_file:
+        description: 'Path to the Dockerfile'
+        default: ''
+        required: false
+        type: string
       docker_secrets:
         description: 'List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)'
         required: false
@@ -113,6 +118,7 @@ jobs:
           # If you Dockerfile is not present in the root directory
           # change it to the correct subdirectory name
           context: ${{ inputs.docker_context }}
+          file: ${{ inputs.docker_file }}
           target: ${{ inputs.docker_target }}
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Overview

Adds custom `Dockerfile` path support to release workflow.

For docker/build-push-action, passing a blank [`file` input](https://github.com/docker/build-push-action#inputs) will work fine (despite their default; see [this file](https://github.com/docker/build-push-action/blob/9472e9021074a3cb3279ba431598b8836d40433f/src/context.ts#L136-L138))