### PR TITLE
feat(releases): add docker build-args input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
         default: '.'
         required: false
         type: string
+      docker_build_args:
+        description: 'additional docker build arguments'
+        required: false
+        type: string
       docker_file:
         description: 'Path to the Dockerfile'
         default: ''
@@ -118,6 +122,7 @@ jobs:
           # If you Dockerfile is not present in the root directory
           # change it to the correct subdirectory name
           context: ${{ inputs.docker_context }}
+          build-args: ${{ inputs.docker_build_args }}
           file: ${{ inputs.docker_file }}
           target: ${{ inputs.docker_target }}
           push: ${{ inputs.push }}


### PR DESCRIPTION
Portals pass in the `TAG` [here](https://github.com/ibm-skills-network/portals/blob/master/.github/workflows/release.yml#L54-L55) to include the tag in the image. This is shown to users in the UI.