### PR TITLE
feat(release): scan images for vulnerabilities before pushing them to icr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ inputs.image }}
+          images: |
+            ${{ inputs.image }}
           # Info: https://github.com/docker/metadata-action#tags-input
           #   - Tag for semantically versioned releases
           #   - Nightly tag ('<latest tag>-YYYYMMDD')
@@ -139,7 +140,7 @@ jobs:
           context: ${{ inputs.docker_context }}
           file: ${{ inputs.docker_file }}
           target: ${{ inputs.docker_target }}
-          push: ${{ inputs.push }}
+          push: true
           tags: ${{ inputs.image }}:scan-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: ${{ steps.should-cache.outputs.cache-from }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           file: ${{ inputs.docker_file }}
           target: ${{ inputs.docker_target }}
           push: ${{ inputs.push }}
-          tags: scan-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          tags: ${{ inputs.image }}:scan-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: ${{ steps.should-cache.outputs.cache-from }}
           cache-to: ${{ steps.should-cache.outputs.cache-to }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ on:
         required: false
       OBAN_LICENSE_KEY:
         required: false
+      TRAVIS_API_TOKEN:
+        required: true
+      CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         description: 'Set to true to scan your container image for vulnerabilities before pushing it to ICR'
         required: true
         type: boolean
-        default: false
+        default: true
       scan_fail_if_overdue:
         description: 'Set to true to prevent images with overdue vulnerabilities from being pushed to ICR'
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ on:
     secrets:
       GH_TOKEN:
         required: false
+      OBAN_KEY_FINGERPRINT:
+        required: false
+      OBAN_LICENSE_KEY:
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Get base release tag
         id: base-release
         run:  |
-          echo "::set-output name=base-release::$(echo '${{ steps.latest-release.outputs.tag_name }}' | sed -r 's/(-[0-9]{8})$//')"
+          echo "base-release=$(echo '${{ steps.latest-release.outputs.tag_name }}' | sed -r 's/(-[0-9]{8})$//')" >> $GITHUB_OUTPUT
+
       - name: print release tag
         run: |
           echo "${{ steps.base-release.outputs.base-release }}"
@@ -83,17 +84,9 @@ jobs:
         if: ${{ github.event_name != 'schedule' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to US ICR
-        uses: docker/login-action@v1
-        with:
-          registry: us.icr.io
-          # These are organization-wide secrets,
-          # so you don't need to configure them on your own
-          username: ${{ secrets.ICR_USERNAME }}
-          password: ${{ secrets.ICR_PASSWORD }}
+        uses: docker/setup-buildx-action@v2
       - name: Login to Global ICR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: icr.io
           # These are organization-wide secrets,
@@ -102,7 +95,7 @@ jobs:
           password: ${{ secrets.ICR_PASSWORD }}
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ inputs.image }}
           # Info: https://github.com/docker/metadata-action#tags-input
@@ -123,15 +116,15 @@ jobs:
         id: should-cache
         run:  |
           if [[ $(date +%a) == 'Sun' ]]; then
-            echo "::set-output name=cache-from::"
-            echo "::set-output name=cache-to::"
+            echo "cache-from=" >> $GITHUB_OUTPUT
+            echo "cache-to=" >> $GITHUB_OUTPUT
           else
             # disable caching on all days until we confirm our "Requires Manual Intervention"
             # issues aren't due to caching issues
-            echo "::set-output name=cache-from::"
-            echo "::set-output name=cache-to::"
-            # echo "::set-output name=cache-from::type=gha"
-            # echo "::set-output name=cache-to::type=gha,mode=max"
+            echo "cache-from=" >> $GITHUB_OUTPUT
+            echo "cache-to=" >> $GITHUB_OUTPUT
+            # echo "cache-to=type=gha" >> $GITHUB_OUTPUT
+            # echo "cache-to=type=gha,mode=max" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push image to scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,9 @@ on:
       OBAN_LICENSE_KEY:
         required: false
       TRAVIS_API_TOKEN:
-        required: true
+        required: false
       CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY:
-        required: true
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Scan image
         if: ${{ inputs.scan_image_enabled }}
-        uses: ibm-skills-network/action-scan-container-image
+        uses: ibm-skills-network/action-scan-container-image@main
         with:
           image: ${{ inputs.image }}:scan-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           travis_api_token: ${{ secrets.TRAVIS_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,7 @@ on:
         required: false
         type: boolean
     secrets:
-      ICR_USERNAME:
-        required: true
-      ICR_PASSWORD:
-        required: true
       GH_TOKEN:
-        required: false
-      NPM_TOKEN:
-        required: true
-      OBAN_KEY_FINGERPRINT:
-        required: false
-      OBAN_LICENSE_KEY:
-        required: false
-      TRAVIS_API_TOKEN:
-        required: false
-      CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY:
         required: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ on:
         type: string
       scan_image_enabled:
         description: 'Set to true to scan your container image for vulnerabilities before pushing it to ICR'
-        required: true
+        required: false
         type: boolean
         default: true
       scan_fail_if_overdue:
         description: 'Set to true to prevent images with overdue vulnerabilities from being pushed to ICR'
-        required: true
+        required: false
         type: boolean
         default: true
       docker_target:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,12 @@ on:
       scan_image_enabled:
         description: 'Set to true to scan your container image for vulnerabilities before pushing it to ICR'
         required: true
+        type: boolean
         default: false
       scan_fail_if_overdue:
         description: 'Set to true to prevent images with overdue vulnerabilities from being pushed to ICR'
         required: true
+        type: boolean
         default: true
       docker_target:
         description: 'Build target for multi-stage docker build'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
         description: 'Full docker image location. e.g. us.icr.io/skills-network-portals/curator'
         required: true
         type: string
+      scan_image_enabled:
+        description: 'Set to true to scan your container image for vulnerabilities before pushing it to ICR'
+        required: true
+        default: false
+      scan_fail_if_overdue:
+        description: 'Set to true to prevent images with overdue vulnerabilities from being pushed to ICR'
+        required: true
+        default: true
       docker_target:
         description: 'Build target for multi-stage docker build'
         default: 'monkey-patched'
@@ -134,8 +142,35 @@ jobs:
             # echo "::set-output name=cache-to::type=gha,mode=max"
           fi
 
+      - name: Build and push image to scan
+        uses: docker/build-push-action@v4
+        with:
+          # If your Dockerfile is not present in the root directory
+          # change it to the correct subdirectory name
+          context: ${{ inputs.docker_context }}
+          file: ${{ inputs.docker_file }}
+          target: ${{ inputs.docker_target }}
+          push: ${{ inputs.push }}
+          tags: scan-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: ${{ steps.should-cache.outputs.cache-from }}
+          cache-to: ${{ steps.should-cache.outputs.cache-to }}
+          secrets: |
+            "oban_key_fingerprint=${{ secrets.OBAN_KEY_FINGERPRINT }}"
+            "oban_license_key=${{ secrets.OBAN_LICENSE_KEY }}"
+            ${{ inputs.docker_secrets }}
+
+      - name: Scan image
+        if: ${{ inputs.scan_image_enabled }}
+        uses: ibm-skills-network/action-scan-container-image
+        with:
+          image: ${{ inputs.image }}:scan-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          travis_api_token: ${{ secrets.TRAVIS_API_TOKEN }}
+          image_scan_result_cos_api_token: ${{ secrets.CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY }}
+          fail_if_overdue: ${{ inputs.scan_fail_if_overdue }}
+
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           # If your Dockerfile is not present in the root directory
           # change it to the correct subdirectory name


### PR DESCRIPTION
See an example of the new action for scanning container images here: https://github.com/ibm-skills-network/action-scan-container-image/actions/runs/4927243464

For most repos, we'll need to update the workflow to look like this:

```yaml
  build:
    uses: ibm-skills-network/.github/.github/workflows/release.yml@main
    secrets: inherit
    with:
      scan_image_enabled: true # optional, can be omitted
      scan_fail_if_overdue: true # optional, can be omitted
```

For repos that need to set `GH_TOKEN` or `OBAN_{KEY_FINGERPRINT, LICENSE_KEY}`, I think they'll need to manually set the new parameters*:
```yaml
 build:
    uses: ibm-skills-network/.github/.github/workflows/release.yml@main
    with:
      scan_image_enabled: true # optional, can be omitted
      scan_fail_if_overdue: true # optional, can be omitted
      travis_api_token: ${{ secrets.TRAVIS_API_TOKEN }} # required if you don't have secrets: inherit
      image_scan_result_cos_api_token: ${{ secrets.CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY }} # required if you don't have secrets: inherit
```

*Not 100% sure, I'm looking into a better way to do this