### PR TITLE
ci(release): prevent images with overdue vulnerabilities from being published to container registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         description: 'Set to true to prevent images with overdue vulnerabilities from being pushed to ICR'
         required: false
         type: boolean
-        default: false
+        default: true
       docker_target:
         description: 'Build target for multi-stage docker build'
         default: 'monkey-patched'


### PR DESCRIPTION
This PR will prevent images with overdue vulnerabilities from being published to our container registry by default. The behaviour can be overridden on a repo-specific level by passing the `scan_fail_if_overdue` input.

We should try to avoid doing this if possible, but there may be some cases where it makes sense. For example, we wouldn't want to prevent publishing an image which resolves a critical vulnerability because of an overdue low severity issue.