### PR TITLE
fix(release): don't try to sign images that haven't been pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,11 +218,14 @@ jobs:
             SN_GITHUB_NPM_REGISTRY=https://npm.pkg.github.com
 
       - uses: sigstore/cosign-installer@main
+        if: ${{ inputs.push }}
 
       - name: Write signing key to disk
+        if: ${{ inputs.push }}
         run: echo "${{ secrets.CONTAINER_IMAGE_SIGNING_PRIVATE_KEY }}" > cosign.key
 
       - name: Sign container image
+        if: ${{ inputs.push }}
         run: |
           cosign sign --key cosign.key \
             -a "repo=${{ github.repository }}" \


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/ibm-skills-network/.github/pull/25. 

This PR makes sure we only try to sign images that actually exist and have been pushed.