### PR TITLE
Skip build and push if image already exists on ICR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
           fail_if_overdue: ${{ inputs.scan_fail_if_overdue }}
         
       - name: Demo - Check icr and compare to current image
-        run: echo "${{ github.ref_name }}"
+        run: echo "${{ github.ref_name }}" -- echo ${{ inputs.image }}
 
       - name: Build and push
         id: build-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,9 +206,9 @@ jobs:
             echo "Image not found in ICR: ${IMAGE}" 
           fi
       
-      - name: Build and push?
+      - name: Skip build and push?
         run: echo "Image is found on ICR, skipping build and push"
-        if: env.IMAGE_EXISTS=="true"
+        if: env.IMAGE_EXISTS=='true'
 
       - name: Build and push
         id: build-push
@@ -232,7 +232,7 @@ jobs:
           build-args: |-
             SN_GITHUB_NPM_TOKEN=${{ secrets.NPM_TOKEN }}
             SN_GITHUB_NPM_REGISTRY=https://npm.pkg.github.com
-        if: env.IMAGE_EXISTS == "false"
+        if: env.IMAGE_EXISTS == 'false'
             
       - uses: sigstore/cosign-installer@main
         if: ${{ inputs.push }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,10 @@ jobs:
             IMAGE_EXISTS=false
             echo "Image not found in ICR: ${IMAGE}" 
           fi
+      
+      - name: Build and push?
+        run: echo "Image is found on ICR, skipping build and push"
+        if: env.IMAGE_EXISTS=="true"
 
       - name: Build and push
         id: build-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,9 +206,14 @@ jobs:
             echo "Image not found in ICR: ${IMAGE}" 
           fi
 
-      - name: Skip build and push?
-        run: echo "Image is found on ICR, skipping build and push"
-        if: env.IMAGE_EXISTS=='true'
+      - name: Fail if image already exists
+        run: |
+          if [ "$IMAGE_EXISTS" == "true" ]; then
+            echo "Image already exists. Failing the release."
+            exit 1
+          fi
+        env:
+          IMAGE_EXISTS: ${{ env.IMAGE_EXISTS }}
 
       - name: Build and push
         id: build-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,10 +199,10 @@ jobs:
         run: |
           IMAGE="${{ inputs.image }}:${{ github.ref_name }}"
           if docker manifest inspect "$IMAGE" &> /dev/null ; then 
-            IMAGE_EXISTS=true >> "$GITHUB_ENV"
+            echo IMAGE_EXISTS=true >> "$GITHUB_ENV"
             echo "Image found in ICR: ${IMAGE}" 
           else 
-            IMAGE_EXISTS=false >> "$GITHUB_ENV"
+            echo IMAGE_EXISTS=false >> "$GITHUB_ENV"
             echo "Image not found in ICR: ${IMAGE}" 
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,13 +199,13 @@ jobs:
         run: |
           IMAGE="${{ inputs.image }}:${{ github.ref_name }}"
           if docker manifest inspect "$IMAGE" &> /dev/null ; then 
-            IMAGE_EXISTS=true
+            IMAGE_EXISTS=true >> $GITHUB_ENV
             echo "Image found in ICR: ${IMAGE}" 
           else 
-            IMAGE_EXISTS=false
+            IMAGE_EXISTS=false >> $GITHUB_ENV
             echo "Image not found in ICR: ${IMAGE}" 
           fi
-      
+
       - name: Skip build and push?
         run: echo "Image is found on ICR, skipping build and push"
         if: env.IMAGE_EXISTS=='true'
@@ -233,7 +233,7 @@ jobs:
             SN_GITHUB_NPM_TOKEN=${{ secrets.NPM_TOKEN }}
             SN_GITHUB_NPM_REGISTRY=https://npm.pkg.github.com
         if: env.IMAGE_EXISTS == 'false'
-            
+
       - uses: sigstore/cosign-installer@main
         if: ${{ inputs.push }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,9 @@ jobs:
           travis_api_token: ${{ secrets.TRAVIS_API_TOKEN }}
           image_scan_result_cos_api_token: ${{ secrets.CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY }}
           fail_if_overdue: ${{ inputs.scan_fail_if_overdue }}
+        
+      - name: Demo - Check icr and compare to current image
+        run: echo "${{ github.ref_name }}"
 
       - name: Build and push
         id: build-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,9 +193,9 @@ jobs:
           travis_api_token: ${{ secrets.TRAVIS_API_TOKEN }}
           image_scan_result_cos_api_token: ${{ secrets.CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY }}
           fail_if_overdue: ${{ inputs.scan_fail_if_overdue }}
-        
+
       - name: Demo - Check icr and compare to current image
-        run: echo "${{ github.ref_name }}" -- echo ${{ inputs.image }}
+        run: echo "{${{ inputs.image }}:"${{ github.ref_name }}}"
 
       - name: Build and push
         id: build-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,10 +199,10 @@ jobs:
         run: |
           IMAGE="${{ inputs.image }}:${{ github.ref_name }}"
           if docker manifest inspect "$IMAGE" &> /dev/null ; then 
-            IMAGE_EXISTS=true >> $GITHUB_ENV
+            IMAGE_EXISTS=true >> "$GITHUB_ENV"
             echo "Image found in ICR: ${IMAGE}" 
           else 
-            IMAGE_EXISTS=false >> $GITHUB_ENV
+            IMAGE_EXISTS=false >> "$GITHUB_ENV"
             echo "Image not found in ICR: ${IMAGE}" 
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,13 +194,16 @@ jobs:
           image_scan_result_cos_api_token: ${{ secrets.CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY }}
           fail_if_overdue: ${{ inputs.scan_fail_if_overdue }}
 
-      - name: Demo - Check Image and give status
+      - name: Check image exist on ICR
+        id: check-image
         run: |
-          echo "Checking if image exist in ICR"
           IMAGE="${{ inputs.image }}:${{ github.ref_name }}"
-          if docker manifest inspect "$IMAGE" 
-          then echo "Image found: ${IMAGE}" 
-          else echo "Image not found: $IMAGE" 
+          if docker manifest inspect "$IMAGE" &> /dev/null ; then 
+            IMAGE_EXISTS=true
+            echo "Image found in ICR: ${IMAGE}" 
+          else 
+            IMAGE_EXISTS=false
+            echo "Image not found in ICR: ${IMAGE}" 
           fi
 
       - name: Build and push
@@ -225,7 +228,8 @@ jobs:
           build-args: |-
             SN_GITHUB_NPM_TOKEN=${{ secrets.NPM_TOKEN }}
             SN_GITHUB_NPM_REGISTRY=https://npm.pkg.github.com
-
+        if: env.IMAGE_EXISTS == "false"
+            
       - uses: sigstore/cosign-installer@main
         if: ${{ inputs.push }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,8 +194,14 @@ jobs:
           image_scan_result_cos_api_token: ${{ secrets.CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY }}
           fail_if_overdue: ${{ inputs.scan_fail_if_overdue }}
 
-      - name: Demo - Output image to push
-        run: echo "{${{ inputs.image }}:${{ github.ref_name }}}"
+      - name: Demo - Check Image and give status
+        run: |
+          echo "Checking if image exist in ICR"
+          IMAGE="${{ inputs.image }}:${{ github.ref_name }}"
+          if docker manifest inspect "$IMAGE" 
+          then echo "Image found: ${IMAGE}" 
+          else echo "Image not found: $IMAGE" 
+          fi
 
       - name: Build and push
         id: build-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,8 +194,8 @@ jobs:
           image_scan_result_cos_api_token: ${{ secrets.CONTAINER_IMAGE_SCAN_RESULT_COS_API_KEY }}
           fail_if_overdue: ${{ inputs.scan_fail_if_overdue }}
 
-      - name: Demo - Check icr and compare to current image
-        run: echo "{${{ inputs.image }}:"${{ github.ref_name }}}"
+      - name: Demo - Output image to push
+        run: echo "{${{ inputs.image }}:${{ github.ref_name }}}"
 
       - name: Build and push
         id: build-push


### PR DESCRIPTION
Added the following steps during the `release.yml` action
1. Check if an image exists on ICR
2. Fails the action if image exists on ICR