### PR TITLE
ci(release): make skills network ca public cert available during builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,10 @@ jobs:
             # echo "cache-to=type=gha,mode=max" >> $GITHUB_OUTPUT
           fi
 
+      - name: Fetch Skills Network Certificate Authority Public Certificate
+        run: |
+          echo "${{ secrets.ROOT_CA_CERTIFICATE_BASE64 }}" | base64 -d > rootCA.crt
+
       - name: Build and push image to scan
         if: ${{ inputs.scan_image_enabled && ( github.ref_type != 'tag' || steps.check-ref.outputs.has_alpha == 'false' ) }}
         uses: docker/build-push-action@v5


### PR DESCRIPTION
After this PR is merged, a Skills Network certificate authority public certificate, `rootCA.crt`, will be available during builds.

Images can choose to trust the Skills Network CA by adding something like this to their Dockerfiles:

```Dockerfile
USER root

COPY rootCA.crt /usr/local/share/ca-certificates/

RUN chmod 644 /usr/local/share/ca-certificates/rootCA.crt && \
  update-ca-certificates
  
USER $USER
```