### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Maximize free space on runner
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 30000
           remove-dotnet: true
           remove-android: true
           remove-haskell: true


### PR DESCRIPTION
Reduced the root reserve for the maximize-build-space action, this got cloud ide to successfully build 