### PR TITLE
Fix Space Freer 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,14 @@ jobs:
           docker-images: true
           swap-storage: true
         if: ${{ inputs.maximize_free_space }}
+      
+      - name: Increase swap space on runner
+        run: |
+          sudo dd if=/dev/zero of=/swapfile bs=1024 count=5000 && \
+          sudo mkswap /swapfile && \
+          sudo swapon -a /swapfile && \
+          sudo swapon -s
+        if: ${{ inputs.maximize_free_space }}
 
       - name: Get latest release tag
         id: latest-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Maximize free space on runner
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 30000
+          root-reserve-mb: 25000
           remove-dotnet: true
           remove-android: true
           remove-haskell: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,15 +77,14 @@ jobs:
           fi
 
       - name: Maximize free space on runner
-        uses: easimon/maximize-build-space@master
+        uses: jlumbroso/free-disk-space@main
         with:
-          root-reserve-mb: 100
-          temp-reserve-mb: 30000
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true # just removes cached images
+          dotnet: true
+          android: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
         if: ${{ inputs.maximize_free_space }}
 
       - name: Get latest release tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,8 @@ jobs:
       - name: Maximize free space on runner
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 25000
+          root-reserve-mb: 100
+          temp-reserve-mb: 30000
           remove-dotnet: true
           remove-android: true
           remove-haskell: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,15 +84,7 @@ jobs:
           haskell: true
           large-packages: true
           docker-images: true
-          swap-storage: true
-        if: ${{ inputs.maximize_free_space }}
-      
-      - name: Increase swap space on runner
-        run: |
-          sudo dd if=/dev/zero of=/swapfile bs=1024 count=5000 && \
-          sudo mkswap /swapfile && \
-          sudo swapon -a /swapfile && \
-          sudo swapon -s
+          swap-storage: false
         if: ${{ inputs.maximize_free_space }}
 
       - name: Get latest release tag


### PR DESCRIPTION
Recent Github actions runner changes have broken the old space freeing action (which I just fixed a month ago !!!), so now we're using a different one that just deletes everything on root without doing anything disk merging.