### PR TITLE
chore(dependency-workflow): add pull_request trigger

### DIFF
--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -1,5 +1,7 @@
 name: Dependency Auto-Merge
-on: workflow_call
+on:
+  workflow_call:
+  pull_request:
 
 jobs:
   dependabot:


### PR DESCRIPTION
In order for the required workflow ruleset rule to work, the pull_request trigger must be added. Ref: https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#supported-event-triggers