### PR TITLE
chore(dependency-auto-merge): adjust triggers to reflect ruleset

### DIFF
--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -1,7 +1,9 @@
+# This workflow is required and run as part of an org-wide ruleset
+
 name: Dependency Auto-Merge
 on:
-  workflow_call:
   pull_request:
+  merge_group:
 
 jobs:
   dependabot:

--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write
+
 jobs:
   dependabot:
     name: Auto-Merge Dependabot PR


### PR DESCRIPTION
Since this workflow is now required as part of an org-wide ruleset, we no longer need synced workflow files and can remove the workflow_call trigger.