### PR TITLE
fix: don't re-publish tagged releases on nightly builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=schedule,pattern=${{ steps.base-release.outputs.base-release }}-{{date 'YYYYMMDD'}}
-            type=schedule,pattern=${{ steps.base-release.outputs.base-release }},enable=${{ github.event_name == 'schedule' }}
             type=raw,value=manual,suffix=${{ github.event.inputs.suffix }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Should we cache


### PR DESCRIPTION
This wouldn't be a problem if we used image digests during deployment everywhere, but until that time let's avoid overwriting tags on nightly builds.