### PR TITLE
Revert "fix: don't re-publish tagged releases on nightly builds"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=schedule,pattern=${{ steps.base-release.outputs.base-release }}-{{date 'YYYYMMDD'}}
+            type=schedule,pattern=${{ steps.base-release.outputs.base-release }},enable=${{ github.event_name == 'schedule' }}
             type=raw,value=manual,suffix=${{ github.event.inputs.suffix }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Should we cache


### PR DESCRIPTION
Reverts ibm-skills-network/.github#50